### PR TITLE
added 'Browser#try' method and 'Browser#open?' method for review.

### DIFF
--- a/watir/lib/watir/loader.rb
+++ b/watir/lib/watir/loader.rb
@@ -8,6 +8,23 @@ module Watir
       # execute just loaded driver's #initialize
       initialize browser.nil? && Watir.driver == :webdriver ? :firefox : browser, *args
     end
+    
+    def try(methodname) #this method is in use in some ruby on rails classes I think. Its the #open? method that I think is the most important though.
+      begin
+        self.send(methodname.to_sym)
+        true
+      rescue
+        false
+	    end
+    end
+
+   def open? #response to http://stackoverflow.com/questions/35283059/how-do-i-find-out-if-a-watir-objects-browser-is-closed-or-not-after-typing-ct/35297847#35297847
+     if try(:exists?)
+	     exists?
+	   else
+	     false
+	   end
+  end
 
     class << self
       def start(url, browser=nil, *args)


### PR DESCRIPTION
added 'Browser#try' method and 'Browser#open?' method for review. Created pull request in response to a question I made on stackoverflow recently which received no suitable responses for my purposes: http://stackoverflow.com/questions/35283059/how-do-i-find-out-if-a-watir-objects-browser-is-closed-or-not-after-typing-ct/35297847#35297847.About the code, #open? currently relies on #try, but if the #open? command is desired and the other is not, the #try? method's code could be extracted into the #open? method.
